### PR TITLE
Add AWS session token variable in configuation file AWS session authe…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3] - 2019-15-11
+### Added
+-  Add AWS token session as optional parameter for session authentication.
+
 ## [0.1.2] - 2019-12-11
 ### Added
 -  Add a possibility to use environment variables for AWS credentials instead of storing key/secret in config.yaml. Before that it was impossible to use STS session (temporary) credentials. You can use aws-vault for running command.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ providers:
     # Environment variables will be used in case if these variables are absent
     access_key: <ACCESS_KEY>
     secret_key: <SECRET_KEY>
-    session_token: ""
+    session_token: "" # Optional variable, on default this variable not set and ignore this value
     regions:
       - <REGION>
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ providers:
     # Environment variables will be used in case if these variables are absent
     access_key: <ACCESS_KEY>
     secret_key: <SECRET_KEY>
+    session_token: ""
     regions:
       - <REGION>
 ```

--- a/config/config.go
+++ b/config/config.go
@@ -11,10 +11,11 @@ import (
 
 // AWSAccount describe AWS account
 type AWSAccount struct {
-	Name      string   `yaml:"name"`
-	AccessKey string   `yaml:"access_key"`
-	SecretKey string   `yaml:"secret_key"`
-	Regions   []string `yaml:"regions"`
+	Name         string   `yaml:"name"`
+	AccessKey    string   `yaml:"access_key"`
+	SecretKey    string   `yaml:"secret_key"`
+	SessionToken string   `yaml:"session_token"`
+	Regions      []string `yaml:"regions"`
 }
 
 // MetricConstraintConfig describe the metric calculator

--- a/provider/aws/run.go
+++ b/provider/aws/run.go
@@ -43,7 +43,7 @@ func (app *Analyze) All() {
 	for _, account := range app.awsAccounts {
 
 		// The pricing aws api working only with us-east-1
-		priceSession := CreateNewSession(account.AccessKey, account.SecretKey, "us-east-1")
+		priceSession := CreateNewSession(account.AccessKey, account.SecretKey, account.SessionToken, "us-east-1")
 		pricing := NewPricingManager(pricing.New(priceSession), "us-east-1")
 
 		for _, region := range account.Regions {
@@ -53,7 +53,7 @@ func (app *Analyze) All() {
 			}).Info("Start to analyze resources")
 
 			// Creating a aws session
-			sess := CreateNewSession(account.AccessKey, account.SecretKey, region)
+			sess := CreateNewSession(account.AccessKey, account.SecretKey, account.SessionToken, region)
 
 			cloudWatchCLient := NewCloudWatchManager(cloudwatch.New(sess))
 

--- a/provider/aws/session.go
+++ b/provider/aws/session.go
@@ -8,14 +8,14 @@ import (
 )
 
 // CreateNewSession return new AWS session
-func CreateNewSession(accessKey, secretKey, region string) *session.Session {
+func CreateNewSession(accessKey, secretKey, sessionToken, region string) *session.Session {
 	var credentialsAWS *credentials.Credentials
 
 	// Use separate call for AWS credentials defined in config.yaml
 	// Otherwise environment variables will be used
 	if accessKey != "" && secretKey != "" {
 		log.Info("Using AccessKey or SecretKey defined in config.yaml")
-		credentialsAWS = credentials.NewStaticCredentials(accessKey, secretKey, "")
+		credentialsAWS = credentials.NewStaticCredentials(accessKey, secretKey, sessionToken)
 	}
 
 	sess := session.Must(session.NewSession(&awsClient.Config{


### PR DESCRIPTION
Hey @cregev,
I have added the option to pass AWS session token when we are initialized AWS session API.
See issue: https://github.com/similarweb/finala/issues/8

For test:  
Run the command:
```sh
$ aws sts get-session-token
```

Set the variables AccessKeyId, SecretAccessKey and SessionToken into config.yaml file.
Then run FInala application 

```sh
$ go run main.go aws -c ./config.yaml
```