### PR TITLE
Ignore Neptune engine in RDS collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Ignore Neptune based instances for RDS instances collection
 
 ## [0.3.3]
 ### Added

--- a/collector/aws/rds.go
+++ b/collector/aws/rds.go
@@ -258,8 +258,9 @@ func (r *RDSManager) DescribeInstances(Marker *string, instances []*rds.DBInstan
 	}
 
 	for _, instance := range resp.DBInstances {
-		// Bug in AWS api response. when filter RDS documentDB returned also.
-		if *instance.Engine != "docdb" {
+		// Ignore DocumentDB and Neptune engine types as we have a seperate
+		// module for them and the default API call returns them
+		if *instance.Engine != "docdb" && *instance.Engine != "neptune" {
 			instances = append(instances, instance)
 		}
 	}


### PR DESCRIPTION
**What type of PR is this?**
Bug

**What this PR does / why we need it**:
Ignores Neptune engine for RDS collection events.

**Which issue(s) this PR fixes (if exists)**:
Fixes #70 