### PR TITLE
create index per day 

### DIFF
--- a/api/config/config.go
+++ b/api/config/config.go
@@ -14,7 +14,6 @@ import (
 type ElasticsearchConfig struct {
 	Username  string   `yaml:"username"`
 	Password  string   `yaml:"password"`
-	Index     string   `yaml:"index"`
 	Endpoints []string `yaml:"endpoints"`
 }
 

--- a/api/storage/elasticsearch/date.go
+++ b/api/storage/elasticsearch/date.go
@@ -2,10 +2,10 @@ package elasticsearch
 
 import "time"
 
-// startTomorrowDate returns the starte tomorrow date.
+// getDayAfterDate returns the starte tomorrow date.
 // Example: dt = 1.1.2020 10:00:00
 // return : 1.2.2020 00:00:00
-func startTomorrowDate(dt time.Time, zone *time.Location) time.Time {
+func getDayAfterDate(dt time.Time, zone *time.Location) time.Time {
 	dt = dt.AddDate(0, 0, 1)
 	return time.Date(dt.Year(), dt.Month(), dt.Day(), 00, 00, 0, 0, zone)
 }

--- a/api/storage/elasticsearch/date.go
+++ b/api/storage/elasticsearch/date.go
@@ -1,0 +1,11 @@
+package elasticsearch
+
+import "time"
+
+// startTomorrowDate returns the starte tomorrow date.
+// Example: dt = 1.1.2020 10:00:00
+// return : 1.2.2020 00:00:00
+func startTomorrowDate(dt time.Time, zone *time.Location) time.Time {
+	dt = dt.AddDate(0, 0, 1)
+	return time.Date(dt.Year(), dt.Month(), dt.Day(), 00, 00, 0, 0, zone)
+}

--- a/api/storage/elasticsearch/date_test.go
+++ b/api/storage/elasticsearch/date_test.go
@@ -5,10 +5,10 @@ import (
 	"time"
 )
 
-func TestStartTomorrowDate(t *testing.T) {
+func TestGetDayAfterDate(t *testing.T) {
 
 	dt := time.Date(2020, 01, 01, 10, 00, 0, 0, time.UTC)
-	tomorrow := startTomorrowDate(dt, time.UTC)
+	tomorrow := getDayAfterDate(dt, time.UTC)
 
 	if tomorrow.Year() != 2020 {
 		t.Fatalf("unexpected year, got %d expected %d", tomorrow.Year(), 2020)

--- a/api/storage/elasticsearch/date_test.go
+++ b/api/storage/elasticsearch/date_test.go
@@ -1,0 +1,33 @@
+package elasticsearch
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStartTomorrowDate(t *testing.T) {
+
+	dt := time.Date(2020, 01, 01, 10, 00, 0, 0, time.UTC)
+	tomorrow := startTomorrowDate(dt, time.UTC)
+
+	if tomorrow.Year() != 2020 {
+		t.Fatalf("unexpected year, got %d expected %d", tomorrow.Year(), 2020)
+	}
+
+	if tomorrow.Month() != 01 {
+		t.Fatalf("unexpected month, got %d expected %d", tomorrow.Month(), 01)
+	}
+
+	if tomorrow.Day() != 02 {
+		t.Fatalf("unexpected day, got %d expected %d", tomorrow.Day(), 02)
+	}
+
+	if tomorrow.Hour() != 00 {
+		t.Fatalf("unexpected hour, got %d expected %d", tomorrow.Hour(), 00)
+	}
+
+	if tomorrow.Minute() != 00 {
+		t.Fatalf("unexpected Minute, got %d expected %d", tomorrow.Hour(), 00)
+	}
+
+}

--- a/api/storage/elasticsearch/elasticsearch.go
+++ b/api/storage/elasticsearch/elasticsearch.go
@@ -94,7 +94,7 @@ func NewStorageManager(conf config.ElasticsearchConfig) (*StorageManager, error)
 		client: esclient,
 	}
 
-	if !storageManager.setCurrentIndexDay() {
+	if !storageManager.setCreateCurrentIndexDay() {
 		return nil, errors.New("could not create index")
 	}
 	go func() {
@@ -107,7 +107,7 @@ func NewStorageManager(conf config.ElasticsearchConfig) (*StorageManager, error)
 			}).Info("change index in")
 			// wait until duration end
 			<-time.After(diff)
-			storageManager.setCurrentIndexDay()
+			storageManager.setCreateCurrentIndexDay()
 		}
 	}()
 
@@ -544,8 +544,8 @@ func (sm *StorageManager) getDurationUntilTomorrow(now time.Time) time.Duration 
 
 }
 
-// setCurrentIndexDay set the current day as index
-func (sm *StorageManager) setCurrentIndexDay() bool {
+// setCreateCurrentIndexDay create and set the current day as index
+func (sm *StorageManager) setCreateCurrentIndexDay() bool {
 	dt := time.Now().In(time.UTC)
 	newIndex := fmt.Sprintf(prefixIndexName, dt.Format("01-02-2006"))
 	log.WithFields(log.Fields{

--- a/api/storage/elasticsearch/elasticsearch.go
+++ b/api/storage/elasticsearch/elasticsearch.go
@@ -19,7 +19,7 @@ import (
 const (
 
 	// prefixDayIndex defins the index name of the current day
-	prefixDayIndex = "finala-%s"
+	prefixIndexName = "finala-%s"
 
 	// indexMapping define the default index mapping
 	indexMapping = `{
@@ -542,7 +542,7 @@ func (sm *StorageManager) checkCurrentIndexDay(now time.Time) {
 
 // setCurrentIndexDay create new index with the given
 func (sm *StorageManager) setCurrentIndexDay(dt time.Time) {
-	newIndex := fmt.Sprintf(prefixDayIndex, dt.Format("01-02-2006"))
+	newIndex := fmt.Sprintf(prefixIndexName, dt.Format("01-02-2006"))
 	log.WithFields(log.Fields{
 		"current_index_day":    sm.currentIndexDay,
 		"to_current_index_day": newIndex,

--- a/configuration/api.yaml
+++ b/configuration/api.yaml
@@ -3,7 +3,6 @@ log_level: info
 
 storage:
   elasticsearch:
-    index: general
     username: ""
     password: ""
     endpoints: 


### PR DESCRIPTION
**What type of PR is this?**

/feature

**What this PR does / why we need it**:
Today, all the detect events save in `general` index.  To improve our performance and add the ability to delete old data we need to save the data in ES in different index 

