### PR TITLE
change download csv file with the name of the resource

### DIFF
--- a/ui/src/components/Dashboard/ResourceTable.js
+++ b/ui/src/components/Dashboard/ResourceTable.js
@@ -190,7 +190,11 @@ const ResourceTable = ({
           <MUIDataTable
             data={currentResourceData}
             columns={headers}
-            options={tableOptions}
+            options={Object.assign(tableOptions, {
+              downloadOptions: {
+                filename: `${currentResource}.csv`,
+              },
+            })}
           />
         </div>
       )}


### PR DESCRIPTION
**What type of PR is this?**

/ UI Feature

**What this PR does / why we need it**:
When we export resource table to csv we need change the file name from the default `tableDownload.csv` to `{resource-name}.csv`
